### PR TITLE
revert to last good version of notebook #126

### DIFF
--- a/notebooks/worksheet1.ipynb
+++ b/notebooks/worksheet1.ipynb
@@ -344,19 +344,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# download data from S3 bucket in data directory\n",
-    "from utils import copy_s3_files, flush_data\n",
-    "\n",
-    "copy_s3_files('s3://ias-pyprecis/data/sample_data.nc', 'data/')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "# import the necessary modules\n",
@@ -368,9 +358,7 @@
     "%matplotlib inline \n",
     "\n",
     "# provide the path of your sample data\n",
-
     "sample_data = 'EAS-22/sample_data.nc'\n",
-
     "\n",
     "# Constraint the reading to a single variable and load it into an Iris cube\n",
     "cube = iris.load_cube(sample_data)\n",
@@ -580,47 +568,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-
    "outputs": [],
    "source": [
     "from iris.experimental.equalise_cubes import equalise_attributes\n",
-
-   "outputs": [],
-   "source": [
-    "# download data from S3 buket to data directory\n",
-    "from utils import copy_s3_files\n",
-    "\n",
-    "copy_s3_files('s3://ias-pyprecis/data/pp/cahpa/*', 'data/pp/cahpa/')\n",
-    "copy_s3_files('s3://ias-pyprecis/data/pp/cahpb/*', 'data/pp/cahpb/')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "datadir = 'data/'\n",
-
     "\n",
     "equalise_attributes(cubes)\n",
     "\n",
-
     "# now print the attributes of each cube\n",
     "for cube in cubes:\n",
     "    print(list(cube.attributes.keys()))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Delete pp data from the disk\n",
-    "from utils import flush_data\n",
-    "flush_data('data/pp/cahpa/*')\n",
-    "flush_data('data/pp/cahpb/*')"
    ]
   },
   {
@@ -726,14 +682,12 @@
    "source": [
     "out_file_name = f'{variable}_{domain}_{gcm}_{experiment}_r1ip1_{rcm}_v2_mon_198912-199111.nc'\n",
     "\n",
-
     "save_location = root_dir + '/cordex_training/'\n",
     "\n",
     "%mkdir {save_location}\n",
     "\n",
     "print('saving file to: ' + save_location + out_file_name)\n",
     "iris.save(sub_cube, save_location + out_file_name)"
-
    ]
   },
   {
@@ -801,11 +755,10 @@
   }
  ],
  "metadata": {
-  "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python [conda env:pyprecis-environment] (arn:aws:sagemaker:eu-west-2:198477955030:image-version/abtraining/1)",
+   "display_name": "pyprecis-environment",
    "language": "python",
-   "name": "conda-env-pyprecis-environment-py__SAGEMAKER_INTERNAL__arn:aws:sagemaker:eu-west-2:198477955030:image-version/abtraining/1"
+   "name": "pyprecis-environment"
   },
   "language_info": {
    "codemirror_mode": {
@@ -825,5 +778,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
This reverts the broken notebook. In the process, the additions for S3 buckets have been removed. This is a temporary measure - we need to further develop all of the content so it can be run on both cloud and local platforms, probably with sections like

if you are on AWS do this:

if you are local do this:

which would be deleted as appropriate for a given training course