### PR TITLE
add in improvements for review #115

### DIFF
--- a/notebooks/worksheet1.ipynb
+++ b/notebooks/worksheet1.ipynb
@@ -750,7 +750,7 @@
     "<a id='1.5'></a>\n",
     "## 1.5 Save data to a new file\n",
     "\n",
-    "We will now save this data to a new file.\n",
+    "**a)** We will now save this data to a new file.\n",
     "\n",
     "Take note of the file names.  Well chosen filenames can help you keep track of the contents of your files.  We suggest developing a consistent syntax based on the filename patterns of the CORDEX data."
    ]
@@ -787,7 +787,7 @@
    "source": [
     "---\n",
     "<div class=\"alert alert-block alert-success\">\n",
-    "<b>Question:</b> Use the <b>cd</b> and <b>ls</b> commands to check the NetCDF directory that you have been creating new files in. <br>\n",
+    "<b>b) Question:</b> Use the <b>cd</b> and <b>ls</b> commands to check the NetCDF directory that you have been creating new files in. <br>\n",
     "\n",
     "- Confirm the names of the new files you have been creating. <br>\n",
     "- What is the size of the concatenated file (containing December 1979 to November 1989 data)?\n",

--- a/notebooks/worksheet1.ipynb
+++ b/notebooks/worksheet1.ipynb
@@ -270,7 +270,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**g)** Now move up two levels in the directory tree and list the directories.\n",
+    "**g)** Now move up one level in the directory tree and list the directories.\n",
     "\n",
     "Type `cd ..` to move up one level in the directory tree and press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to execute the command"
    ]
@@ -318,27 +318,36 @@
     "Python is a general purpose programming language. Python supports modules and packages, which encourages program modularity and code reuse. \n",
     "\n",
     "\n",
-    "We also use the Python library [Iris](http://scitools.org.uk/iris/docs/latest/index.html), which is written in Python and is maintained by the Met Office. Iris seeks to provide a powerful, easy to use, and community-driven Python library for analysing and visualising meteorological and oceanographic data sets.\n",
+    "We also use the Python library [Iris](http://scitools.org.uk/iris/docs/v2.4.0/index.html), which is written in Python and is maintained by the Met Office. Iris seeks to provide a powerful, easy to use, and community-driven Python library for analysing and visualising meteorological and oceanographic data sets.\n",
     "\n",
-    "The top level object in Iris is called a <b>cube</b>. A cube contains data and metadata about a phenomenon (i.e. air_temperature). Iris handles several different types of file formats, loadiing them into Iris cubes.\n",
+    "The top level object in Iris is called a <b>cube</b>. A cube contains data and metadata about a phenomenon (i.e. air_temperature). Iris handles several different types of file formats, loading them into Iris cubes.\n",
     "\n",
     "\n",
     "For a brief introduction to Iris and the cube formatting please read this Introduction page here: \n",
     "\n",
-    "http://scitools.org.uk/iris/docs/latest/userguide/iris_cubes.html\n",
+    "http://scitools.org.uk/iris/docs/v2.4.0/userguide/iris_cubes.html\n",
     "\n",
     "For future reference please refer to the Iris website:\n",
     "\n",
-    "http://scitools.org.uk/iris/docs/latest/index.html\n"
+    "http://scitools.org.uk/iris/docs/v2.4.0/index.html\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, run the code-block below to **load** a file into Iris and **print** its metadata structure. <br>\n",
+    "**a)** First, run the code-block below to **load** a file into Iris and **print** its metadata structure. <br>\n",
     "\n",
     "To run the code, click in the box below and press <kbd>Ctrl</kbd> + <kbd>Enter</kbd>."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd /home/h03/fris/code/PyPRECIS/notebooks/data_v2"
    ]
   },
   {
@@ -388,7 +397,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<b>Answer</b>:\n",
+    "<b>Double click here to type your answer:</b>:\n",
     "<br>*Is this cube 3D or 2D? \n",
     "<br>What are the cube dimensions? \n",
     "<br>How many grid boxes is the latitudinal range divided into? \n",
@@ -402,7 +411,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**i)** Now **plot** the data for the selected variable: <br>\n",
+    "**b)** Now **plot** the data for the selected variable: <br>\n",
     "\n",
     "To run the code, click in the box below and press <kbd>Ctrl</kbd> + <kbd>Enter</kbd>."
    ]
@@ -417,6 +426,11 @@
     "import iris.quickplot as qplt\n",
     "\n",
     "plt.figure(figsize=(12,12))  # Set the figure size\n",
+    "\n",
+    "# find the edges of grid cells (Aka the boounds)\n",
+    "cube.coord('grid_latitude').guess_bounds()\n",
+    "cube.coord('grid_longitude').guess_bounds()\n",
+    "\n",
     "qplt.pcolormesh(cube)  # Plot the cube\n",
     "plt.title(cube.name())  # Add plot title\n",
     "plt.clim(0, 5e-4)  # Set colour bar range\n",
@@ -427,10 +441,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='1.3'></a>\n",
-    "## Merge problems\n",
+    "<div class=\"alert alert-block alert-success\">\n",
+    "Sense check the data plotted: \n",
     "\n",
-    "When using data, we want a single cube for all fields with the same standard name and seequential timesteps. `iris.load` will return as few cubes as possible, by collecting cubes from multiple files together. However, on some occasions this merge process does not give a single cube when we would expect it to. \n",
+    "* Can you make out sections of the East Asian coastline? \n",
+    "* How about the scale? \n",
+    "\n",
+    "As we progress through these workbooks, we'll learn how to process the data into more intuitive units and mask / add country boundaries, so it's easier to understand the information.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='1.3'></a>\n",
+    "## 1.3 Merge problems\n",
+    "\n",
+    "**a)** When using data, we want a single cube for all fields with the same standard name and sequential timesteps. `iris.load` will return as few cubes as possible, by collecting cubes from multiple files together. However, on some occasions this merge process does not give a single cube when we would expect it to. \n",
     "\n",
     "This section demonstrates how to deal with cases like this and make a single cube for these data."
    ]
@@ -448,7 +476,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As an example we will load some data from the West Asia Domain at 50 km resolution"
+    "As an example we will load some temperature data from the [East Asia Domain](https://cordex.org/domains/region-7-east-asia/) at 25 km resolution"
    ]
   },
   {
@@ -484,7 +512,7 @@
     "file_name = variable+\"*\"+gcm+\"*\"+experiment+\"*\"+rcm+\"*\"\n",
     "file_list = glob.glob(path_dir+file_name)\n",
     "\n",
-    "# complete the print statement below to check the files being loaded\n",
+    "# Complete the print statement to see which East Asian files match the specified criteria\n",
     "print()"
    ]
   },
@@ -492,7 +520,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we try and force Iris to load a single cube we get an error:"
+    "<div class=\"alert alert-block alert-success\">\n",
+    "How many files were returned?    \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Double click here to type your answer:**\n",
+    "\n",
+    "How many files were returned?   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**b)** If we try and force Iris to load a single cube we get an error:"
    ]
   },
   {
@@ -552,7 +598,7 @@
     "<br>Are they all the same size in space?\n",
     "<br>Do they have the same number of timesteps? Why do you think this is? (Hint: look again at the filenames we are loading)\n",
     "<br>What are the differences in the attributes?\n",
-    "<br>Do you think these differnces are important when analysing your data?* \n",
+    "<br>Do you think these differences are important when analysing your data?* \n",
     "\n",
     "---"
    ]
@@ -561,7 +607,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's solve this problem so we can get a single cube. We will do this using the [equalise_attributes](https://scitools.org.uk/iris/docs/v2.4.0/iris/iris/experimental/equalise_cubes.html) function from Iris."
+    "**c)** Now let's solve this problem so we can get a single cube. We will do this using the [equalise_attributes](https://scitools.org.uk/iris/docs/v2.4.0/iris/iris/experimental/equalise_cubes.html) function from Iris."
    ]
   },
   {
@@ -597,7 +643,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<b>Answer</b>:\n",
+    "<b>Type your answer:</b>:\n",
     "<br>*Why might it be a bad idea to apply this function without looking at the data first?*"
    ]
   },
@@ -616,7 +662,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now merge the data into a single cube."
+    "**d)** We can now merge the data into a single cube."
    ]
   },
   {
@@ -633,10 +679,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<li> Now that we have combined multiple files into a single cube, what is the cube's shape? \n",
+    "<li> How does this compare with the cube_list created in 1.2e? \n",
+    "<li> Based on all the information you've gained about the data so far, what time period do you expect the data in this cube to span?\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Type your answers here**\n",
+    "* Now that we have combined multiple files into a single cube, what is the cube's shape? \n",
+    "*  How does this compare with the cube_list created in 1.2e? \n",
+    "* Based on all the information you've gained about the data so far, what time period do you expect the data in this cube to span?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<a id='1.4'></a>\n",
-    "# Extracting data within a specific time range\n",
+    "## 1.4 Extracting data within a specific time range\n",
     "\n",
-    "This is a lot of data, and so for now, we will cut this down to include December 1989 to November 1991 inclusive using a time constraint."
+    "**a)** This is a lot of data, and so for now, we will cut this down to include December 1989 to November 1991 inclusive using a time constraint. Edit the code below to specify the missing end date.\n",
+    "(**Hint:** specify the adjacent months BEFORE and AFTER the time period you wish to keep.)"
    ]
   },
   {
@@ -652,10 +720,23 @@
     "print(cube.coord(\"time\")[-1])\n",
     "\n",
     "time_constraint = iris.Constraint(time=lambda cell: PartialDateTime(year=1989,month=11) \n",
-    "                            < cell.point < PartialDateTime(year=1991,month=12))\n",
-    "sub_cube = cube.extract(time_constraint)\n",
-    "\n",
-    "\n",
+    "                            < cell.point < PartialDateTime(year=YYYY,month=MM))\n",
+    "sub_cube = cube.extract(time_constraint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**b)** Check the first and last timesteps in your constrained cube are correct:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "print()\n",
     "print('new cube first and last dates')\n",
     "print(sub_cube.coord(\"time\")[0])\n",
@@ -667,11 +748,11 @@
    "metadata": {},
    "source": [
     "<a id='1.5'></a>\n",
-    "# Saving data to a new file\n",
+    "## 1.5 Save data to a new file\n",
     "\n",
     "We will now save this data to a new file.\n",
     "\n",
-    "Take note of the file names.  Good use of filename can help you keep track of the contents of your files.  We suggest developing a consistent syntax based on the filename patterns of the CORDEX data."
+    "Take note of the file names.  Well chosen filenames can help you keep track of the contents of your files.  We suggest developing a consistent syntax based on the filename patterns of the CORDEX data."
    ]
   },
   {
@@ -682,7 +763,7 @@
    "source": [
     "out_file_name = f'{variable}_{domain}_{gcm}_{experiment}_r1ip1_{rcm}_v2_mon_198912-199111.nc'\n",
     "\n",
-    "save_location = root_dir + '/cordex_training/'\n",
+    "save_location = root_dir + 'cordex_training/'\n",
     "\n",
     "%mkdir {save_location}\n",
     "\n",
@@ -695,7 +776,8 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> Keep a note of how we update the file names as we progress through these worksheets making further changes to the data\n",
+    "<b>Note:</b>\n",
+    "As we progress through these worksheets, keep a note of how we update the file names when making further changes to the data.\n",
     "</div>"
    ]
   },
@@ -750,7 +832,7 @@
    "metadata": {},
    "source": [
     "<p><img src=\"img/MO_MASTER_black_mono_for_light_backg_RBG.png\" alt=\"python + iris logo\" style=\"float: center; height: 100px;\"/></p>\n",
-    "<center>© Crown Copyright 2019, Met Office</center>"
+    "<center>© Crown Copyright 2022, Met Office</center>"
    ]
   }
  ],

--- a/notebooks/worksheet2.ipynb
+++ b/notebooks/worksheet2.ipynb
@@ -753,7 +753,7 @@
    "metadata": {},
    "source": [
     "<p><img src=\"img/MO_MASTER_black_mono_for_light_backg_RBG.png\" alt=\"python + iris logo\" style=\"float: center; height: 100px;\"/></p>\n",
-    "<center>© Crown Copyright 2019, Met Office</center>"
+    "<center>© Crown Copyright 2022, Met Office</center>"
    ]
   }
  ],

--- a/notebooks/worksheet3.ipynb
+++ b/notebooks/worksheet3.ipynb
@@ -1023,7 +1023,7 @@
    "metadata": {},
    "source": [
     "<p><img src=\"img/MO_MASTER_black_mono_for_light_backg_RBG.png\" alt=\"python + iris logo\" style=\"float: center; height: 100px;\"/></p>\n",
-    "<center>© Crown Copyright 2019, Met Office</center>"
+    "<center>© Crown Copyright 2022, Met Office</center>"
    ]
   }
  ],

--- a/notebooks/worksheet4.ipynb
+++ b/notebooks/worksheet4.ipynb
@@ -601,7 +601,7 @@
    "metadata": {},
    "source": [
     "<p><img src=\"img/MO_MASTER_black_mono_for_light_backg_RBG.png\" alt=\"python + iris logo\" style=\"float: center; height: 100px;\"/></p>\n",
-    "<center>© Crown Copyright 2019, Met Office</center>"
+    "<center>© Crown Copyright 2022, Met Office</center>"
    ]
   }
  ],

--- a/notebooks/worksheet5.ipynb
+++ b/notebooks/worksheet5.ipynb
@@ -838,7 +838,7 @@
    "metadata": {},
    "source": [
     "<p><img src=\"img/MO_MASTER_black_mono_for_light_backg_RBG.png\" alt=\"python + iris logo\" style=\"float: center; height: 100px;\"/></p>\n",
-    "<center>© Crown Copyright 2019, Met Office</center>"
+    "<center>© Crown Copyright 2022, Met Office</center>"
    ]
   }
  ],


### PR DESCRIPTION
response to review:

Review of sections 1.1-1.2 (User testing)

    L275: Just checking that the latest version moves up ONE level, not two (into data_v2).
fixed
    L315: Python & Iris logo doesn't load
Works for me. This is probably due to me just sending you the notebook - the images are in the img folder I didn't send

    L323: (e.g. air_temperature). Typo: loading
Fixed

    L328: broken link. Replace with https://scitools-iris.readthedocs.io/en/stable/userguide/iris_cubes.html
Pointed at final 2.x version as not using Iris 3 yet

    L389: image of a cube doesn't load
Works for me - see above

    L403: Replace "answer" with "Double click here to type your answer"
done

    L431: plotting throws 2 UserWarnings: grid lat/lon is not bounded, guessing contiguous bounds. Can bounds be added, or the warning message suppressed?
done

    L431: It'd be nice to replace the omitted question / comment about the plot to end this section. e.g. "Sense check the data plotted: Can you make out sections of the East Asian coastline? How about the scale? As we progress through these workbooks, we'll learn how to process the data into more intuitive units and mask / add country boundaries, so it's easier to understand the information."
Done

Section 1.3 Merge Problems

    L443: Add section number (1.3) to title
Done
    L445: typo "sequential"
Done
    L455: links to an old version of Iris. Replace link with latest stable vn: https://scitools-iris.readthedocs.io/en/stable/userguide/loading_iris_cubes.html
Intentional as this is the version the notebooks use at present
    L463: Reference to 'West Asia' domain. Do you mean EAST Asia? If not, the CORDEX West Asia domain appears to have been renamed 'South Asia'. Can we follow suit? Also, hyperlink to the domain info? https://cordex.org/domains/region-6-south-asia-2/ New text: "some temperature data from the West Asia CORDEX Domain".
fixed
    L484: Make it more explicit that the earner is expected to edit the code block. e.g. "Complete the print statement to see which East Asian files match the specified criteria."
Done
    L503: Add a question: "How many files were returned?" (Answer: 3)
Done
    L567: Typo: differences
fixed
    L576: links to vn2.4 of Iris. Perhaps replace with this link? https://scitools-iris.readthedocs.io/en/stable/generated/api/iris/util.html#iris.util.equalise_attributes
See above

· Section 1.1 helpfully labels the steps (i.e. 1.1 a-g). Please could this be done in other sections as well? e.g. L339: "a) First, ..." It'd be helpful if teaching in a classroom / referring back to sections in later questions.
e.g. L339: a) First, …
Done
· L417: replace i)with b)
Done
· L586: Error: Exception: The function "iris.experimental.equalise_cubes.equalise_attributes" has been moved.
Please replace "iris.experimental.equalise_cubes.equalise_attributes()" with "iris.util.equalise_attributes()".
(Actioned replacement to continue testing)
This is due to you using scitools/default - this works ok at 2.4 as used here (I should have told you to install the kernel)
· L675: Always nice to end a section with a reflective question on what has been achieved. e.g. Now that we have combined multiple files into a single cube, what is the cube's shape? How does this compare with the cube_list created in 1.2e? Based on all the information you've gained about the data so far, what time period do you expect the data in this cube to span?(ANSWER: Jan 1981 - Dec 2005, noting this is only from the filenames, which could be misdirecting)
Done
· L681: Add 1.4to section title (Extracting Data)
Done
· L683: How about making this an interactive step?
"This is a lot of data, so we will cut this down using a time constraint. We only want the cube to include data from December 1989 to November 1991 (inclusive). Edit the code below to specify the missing end date.
(Hint: specify the adjacent months BEFORE and AFTER the time period you wish to keep.)"
Done
· L698-699:
time_constraint = iris.Constraint(time=lambda cell: PartialDateTime(year=1989,month=11) \n, < cell.point < PartialDateTime(year=YYYY, month=MM))\n
L703: (split code block into two parts) "Check the first and last timesteps in your constrained cube are correct:"
Done
· L714: Add 1.5to section title (Saving Data)
Done
· L716: save
DONE
· L718: Rephrase Good use of filenameas Well-written filenames?
I went with "well chosen"
· L730: save_locationoutputs a double slash: .//cordex_training. Omit extra /on this line
Done
· L744: Grammar? As we progress through these worksheets, keep a note of how we update the file names when making further changes to the data.
· Done

· L798: Broken Iris image.
· See above
· L799: Update copyright year from 2019.
Done in all notebooks