### PR TITLE
small changes to environment.yml to mitigate issues with libwebp-base

### DIFF
--- a/pyprecis-environment.lock.yml
+++ b/pyprecis-environment.lock.yml
@@ -86,6 +86,7 @@ dependencies:
   - font-ttf-source-code-pro=2.038
   - font-ttf-ubuntu=0.83
   - fontconfig=2.14.2
+  - fonts-anaconda=1
   - fonts-conda-ecosystem=1
   - fonts-conda-forge=1
   - fonttools=4.41.1
@@ -100,7 +101,7 @@ dependencies:
   - glib-tools=2.76.4
   - glog=0.6.0
   - graphite2=1.3.13
-  - gsl=2.7
+  - gsl=2.7.1
   - gst-plugins-base=1.22.5
   - gstreamer=1.22.5
   - harfbuzz=7.3.0
@@ -182,6 +183,7 @@ dependencies:
   - libogg=1.3.4
   - libopenblas=0.3.23
   - libopus=1.3.1
+  - libpnetcdf=1.12.3
   - libpng=1.6.39
   - libpq=15.3
   - libprotobuf=4.23.3
@@ -196,7 +198,7 @@ dependencies:
   - libutf8proc=2.8.0
   - libuuid=2.38.1
   - libvorbis=1.3.7
-  - libwebp-base=1.3.1
+  - libwebp-base=1.3.2
   - libxcb=1.15
   - libxkbcommon=1.5.0
   - libxml2=2.11.4
@@ -214,6 +216,8 @@ dependencies:
   - mistune=3.0.0
   - mo_pack=0.2.0
   - mpg123=1.31.3
+  - mpi=1.0
+  - mpich=4.1.1
   - msgpack-python=1.0.5
   - munkres=1.1.4
   - mysql-common=8.0.33
@@ -232,7 +236,7 @@ dependencies:
   - notebook=7.0.0
   - notebook-shim=0.2.3
   - nspr=4.35
-  - nss=3.89
+  - nss=3.89.1
   - numpy=1.25.1
   - openjpeg=2.5.0
   - openssl=3.1.1
@@ -242,6 +246,7 @@ dependencies:
   - pandas=2.0.3
   - pandocfilters=1.5.0
   - pango=1.50.14
+  - parallelio=2.6.0
   - parso=0.8.3
   - partd=1.4.0
   - pcre2=10.40
@@ -367,4 +372,3 @@ dependencies:
   - zipp=3.16.2
   - zlib=1.2.13
   - zstd=1.5.2
- 


### PR DESCRIPTION
add small updates to pyprecis environment to pick up latest version of libwebp-base 

created by:
1. conda activate pyprecis-environment
2. conda install --no-deps -c conda-forge -y libwebp-base>=1.3.2
3. conda env export --no-builds pyprecis-environment.lock.yml

To test ran notebooks 1-3 from both domains